### PR TITLE
Fix function type workaround

### DIFF
--- a/src/ByteBeatCompiler.js
+++ b/src/ByteBeatCompiler.js
@@ -259,7 +259,7 @@ export default class ByteBeatCompiler {
     delete keys['Math'];
     delete keys['window'];
     return `
-        (0['constructor']['constructor'] = '');
+        (Function.prototype.constructor = '');
         var ${Object.keys(keys).sort().join(',\n')};
         ${ByteBeatCompiler.addGlobals(Math, 'Math')}
     `;


### PR DESCRIPTION
Only the constructor of Number used to be cleared, now it should clear all functions.